### PR TITLE
Make the app work on Render

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,11 +55,6 @@ app.use((req, res, next) => {
 		res.redirect('//' + req.get('Host') + ':8080');
 		return;
 	}
-	if (PORT != 8080 && req.get('Host') == 'webedit.app.render.com') {
-		console.log('vhosttru', req.get('Host'));
-		res.redirect('//' + req.get('Host') + ':10000');
-		return;
-	}
 	next();
 });
 

--- a/app.js
+++ b/app.js
@@ -102,7 +102,7 @@ app.use(function (req, res) {
 });
 
 // Start the server
-app.listen(PORT, () => {
+app.listen(PORT, "0.0.0.0", () => {
 	console.log(`App listening on port ${PORT}`);
 	console.log('Press Ctrl+C to quit.');
 });


### PR DESCRIPTION
The biggest change is to listen on all ipv4 interfaces in `app.listen`. We also don't need to redirect for Render or use specific ports.